### PR TITLE
Corrected formatting in po/inputmethod-plug.pot

### DIFF
--- a/po/inputmethod-plug.pot
+++ b/po/inputmethod-plug.pot
@@ -85,8 +85,7 @@ msgid "Your Input Method Is Not Supported"
 msgstr ""
 
 #: src/Plug.vala:85
-msgid ""
-"The default input method of the system is not configurable in this Plug."
+msgid "The default input method of the system is not configurable in this Plug."
 msgstr ""
 
 #: src/Plug.vala:86


### PR DESCRIPTION
Hey, Ryoさん! インプットメソッドのプラグを作ってありがとう。たしかに便利になるよ!

さ、ふらっとinputmethod-plug.potに文字列の違いを見つけたんだね。正しいかどうか知らなかったけど、「サポートされていない」メッセージが英語で見えなかったから、その違いを訂正しようとした。 🤷‍♂️️

どうなるかな?